### PR TITLE
[16.0][FIX] automation_oca: pass eval_context in domain

### DIFF
--- a/automation_oca/models/automation_configuration_step.py
+++ b/automation_oca/models/automation_configuration_step.py
@@ -265,12 +265,14 @@ class AutomationConfigurationStep(models.Model):
     )
     def _compute_applied_domain(self):
         for record in self:
+            eval_context = record.configuration_id._get_eval_context()
             record.applied_domain = expression.AND(
                 [
-                    safe_eval(record.domain),
+                    safe_eval(record.domain, eval_context),
                     safe_eval(
                         (record.parent_id and record.parent_id.applied_domain)
-                        or record.configuration_id.domain
+                        or record.configuration_id.domain,
+                        eval_context,
                     ),
                 ]
             )


### PR DESCRIPTION
Hello,
 Following my first pr #8 , when we use a domain with today, datetime etc, we have an error when we add step.
So I add context in safe_eval contained in the step file.