### PR TITLE
[FIX][16.0] automation_oca: pass eval_context in record step domain safe_eval

### DIFF
--- a/automation_oca/models/automation_record_step.py
+++ b/automation_oca/models/automation_record_step.py
@@ -123,7 +123,10 @@ class AutomationRecordStep(models.Model):
         if (
             self.record_id.resource_ref is None
             or not self.record_id.resource_ref.filtered_domain(
-                safe_eval(self.configuration_step_id.applied_domain)
+                safe_eval(
+                    self.configuration_step_id.applied_domain,
+                    self.configuration_step_id.configuration_id._get_eval_context(),
+                )
             )
             or not self._check_to_execute()
         ):


### PR DESCRIPTION
Hello,
Following my first pr https://github.com/OCA/automation/pull/8 , when we use a domain with today, datetime etc, we have an error when we add record step.
So I add context in safe_eval contained in the record step file.

I check, all safe_eval are context now, sorry for this new pr for the same problem.