### PR TITLE
[16.0][IMP] automation_oca: Allow to enforce a complete different domain on an step

### DIFF
--- a/automation_oca/views/automation_configuration_step.xml
+++ b/automation_oca/views/automation_configuration_step.xml
@@ -131,6 +131,9 @@
                     </group>
                     <notebook>
                         <page string="Specific Domain" name="specific_domain">
+                            <group>
+                                <field name="apply_parent_domain" />
+                            </group>
                             <field
                                 name="domain"
                                 widget="domain"


### PR DESCRIPTION
This might be interesting if we have a filter that might be modified over time.

For example, we start with `draft` sale orders but we expect them to change state during the process.