### PR TITLE
[16.0][IMP] automation_oca: Allow to force execution with previous step finalization

### DIFF
--- a/automation_oca/README.rst
+++ b/automation_oca/README.rst
@@ -130,6 +130,10 @@ Step execution
 Steps are executed using a cron action. This action is executed every
 hour by default. On the record view, you can execute manually an action.
 
+There is a way to enforce step execution when finalize the previous one.
+If we set a negative value on the period, the execution will be
+immediate without a cron.
+
 .. |Configuration Screenshot| image:: https://raw.githubusercontent.com/OCA/automation/16.0/automation_oca/static/description/configuration.png
 
 Bug Tracker

--- a/automation_oca/readme/USAGE.md
+++ b/automation_oca/readme/USAGE.md
@@ -54,3 +54,6 @@ Step execution
 
 Steps are executed using a cron action. This action is executed every hour by default.
 On the record view, you can execute manually an action.
+
+There is a way to enforce step execution when finalize the previous one.
+If we set a negative value on the period, the execution will be immediate without a cron.

--- a/automation_oca/static/description/index.html
+++ b/automation_oca/static/description/index.html
@@ -481,6 +481,9 @@ hours by default.</p>
 <h2><a class="toc-backref" href="#toc-entry-5">Step execution</a></h2>
 <p>Steps are executed using a cron action. This action is executed every
 hour by default. On the record view, you can execute manually an action.</p>
+<p>There is a way to enforce step execution when finalize the previous one.
+If we set a negative value on the period, the execution will be
+immediate without a cron.</p>
 </div>
 </div>
 <div class="section" id="bug-tracker">

--- a/automation_oca/tests/test_automation_action.py
+++ b/automation_oca/tests/test_automation_action.py
@@ -5,6 +5,22 @@ from .common import AutomationTestCase
 
 
 class TestAutomationAction(AutomationTestCase):
+    def test_activity_immediate_execution(self):
+        """
+        We will check the execution of the tasks and that we cannot execute them again
+        """
+        activity = self.create_server_action(trigger_interval=-1)
+        self.configuration.editable_domain = "[('id', '=', %s)]" % self.partner_01.id
+        self.configuration.start_automation()
+        self.env["automation.configuration"].cron_automation()
+        self.assertFalse(self.partner_01.comment)
+        self.assertTrue(self.partner_02.comment)
+        record_activity = self.env["automation.record.step"].search(
+            [("configuration_step_id", "=", activity.id)]
+        )
+        self.assertEqual(1, len(record_activity))
+        self.assertEqual("done", record_activity.state)
+
     def test_activity_execution(self):
         """
         We will check the execution of the tasks and that we cannot execute them again

--- a/automation_oca/views/automation_configuration.xml
+++ b/automation_oca/views/automation_configuration.xml
@@ -252,10 +252,19 @@
                                                     aria-label="Select time"
                                                     title="Select time"
                                                 />
-                                                <span class="pe-1"><field
-                                                        name="trigger_interval"
-                                                    /></span>
-                                                <field name="trigger_interval_type" />
+                                                <t
+                                                    t-if="record.trigger_interval.raw_value >= 0"
+                                                >
+                                                    <span class="pe-1"><field
+                                                            name="trigger_interval"
+                                                        /></span>
+                                                    <field
+                                                        name="trigger_interval_type"
+                                                    />
+                                                </t>
+                                                <t t-else="">
+                                                    <span class="pe-1">Immediatly</span>
+                                                </t>
                                             </strong>
                                         </div>
                                     </div>

--- a/automation_oca/views/automation_configuration_step.xml
+++ b/automation_oca/views/automation_configuration_step.xml
@@ -15,6 +15,13 @@
                                 placeholder="e.g. Remember unpaid invoices"
                             /></h1>
                     </div>
+                    <div
+                        class="alert alert-warning"
+                        role="alert"
+                        attrs="{'invisible': [('trigger_interval', '>=', 0)]}"
+                    >
+                        In this case, the task will be executed automatically when we create it in the same process.
+                    </div>
                     <group>
                         <group>
                             <field name="step_type" />


### PR DESCRIPTION
This is useful if we want to create chained activities for example.

We should wait for #20 to make it better. We should check for the date of the scheduled date to after now.