### PR TITLE
[16.0][IMP] automation_oca: Allow to force scheduled date with a date of the record

### DIFF
--- a/automation_oca/models/automation_configuration_step.py
+++ b/automation_oca/models/automation_configuration_step.py
@@ -45,6 +45,14 @@ class AutomationConfigurationStep(models.Model):
     )
     step_icon = fields.Char(compute="_compute_step_info")
     step_name = fields.Char(compute="_compute_step_info")
+    trigger_date_kind = fields.Selection(
+        [
+            ("offset", "Offset"),
+            ("date", "Force on Record Date"),
+        ],
+        required=True,
+        default="offset",
+    )
     trigger_interval_hours = fields.Integer(
         compute="_compute_trigger_interval_hours", store=True
     )
@@ -56,6 +64,11 @@ class AutomationConfigurationStep(models.Model):
     trigger_interval_type = fields.Selection(
         [("hours", "Hour(s)"), ("days", "Day(s)")], required=True, default="hours"
     )
+    trigger_date_field_id = fields.Many2one(
+        "ir.model.fields",
+        domain="[('model_id', '=', model_id), ('ttype', 'in', ['date', 'datetime'])]",
+    )
+    trigger_date_field = fields.Char(related="trigger_date_field_id.field_description")
     allow_expiry = fields.Boolean(compute="_compute_allow_expiry")
     expiry = fields.Boolean(compute="_compute_expiry", store=True, readonly=False)
     expiry_interval = fields.Integer()
@@ -510,8 +523,8 @@ class AutomationConfigurationStep(models.Model):
         for record in self:
             record._check_configuration()
 
-    def _get_record_activity_scheduled_date(self):
-        if self.trigger_type in [
+    def _get_record_activity_scheduled_date(self, record, force=False):
+        if not force and self.trigger_type in [
             "mail_open",
             "mail_bounce",
             "mail_click",
@@ -522,7 +535,15 @@ class AutomationConfigurationStep(models.Model):
             "activity_cancel",
         ]:
             return False
-        return fields.Datetime.now() + relativedelta(
+        if (
+            self.trigger_date_kind == "date"
+            and self.trigger_date_field_id
+            and record[self.trigger_date_field_id.name]
+        ):
+            date = fields.Datetime.to_datetime(record[self.trigger_date_field_id.name])
+        else:
+            date = fields.Datetime.now()
+        return date + relativedelta(
             **{self.trigger_interval_type: self.trigger_interval}
         )
 
@@ -534,7 +555,7 @@ class AutomationConfigurationStep(models.Model):
         )
 
     def _create_record_activity_vals(self, record, **kwargs):
-        scheduled_date = self._get_record_activity_scheduled_date()
+        scheduled_date = self._get_record_activity_scheduled_date(record)
         do_not_wait = scheduled_date and scheduled_date < fields.Datetime.now()
         return {
             "configuration_step_id": self.id,

--- a/automation_oca/models/automation_record_step.py
+++ b/automation_oca/models/automation_record_step.py
@@ -323,8 +323,8 @@ class AutomationRecordStep(models.Model):
         current_date = fields.Datetime.now()
         for record in todo:
             config = record.configuration_step_id
-            scheduled_date = fields.Datetime.now() + relativedelta(
-                **{config.trigger_interval_type: config.trigger_interval}
+            scheduled_date = config._get_record_activity_scheduled_date(
+                record.record_id.resource_ref, force=True
             )
             record.write(
                 {

--- a/automation_oca/tests/test_automation_base.py
+++ b/automation_oca/tests/test_automation_base.py
@@ -361,6 +361,38 @@ class TestAutomationBase(AutomationTestCase):
                 record_activity.scheduled_date, datetime(2022, 1, 1, 1, 0, 0, 0)
             )
 
+    def test_schedule_date_force(self):
+        partner_01 = self.env["res.partner"].create(
+            {
+                "name": "Demo partner",
+                "comment": "Demo",
+                "email": "test@test.com",
+                "date": "2025-01-01",
+            }
+        )
+        with freeze_time("2024-01-01 00:00:00"):
+            activity = self.create_server_action(
+                trigger_date_kind="date",
+                trigger_date_field_id=self.env["ir.model.fields"]
+                .search(
+                    [
+                        ("name", "=", "date"),
+                        ("model", "=", "res.partner"),
+                    ]
+                )
+                .id,
+                trigger_interval=1,
+                trigger_interval_type="days",
+            )
+            self.configuration.editable_domain = "[('id', '=', %s)]" % partner_01.id
+            self.configuration.start_automation()
+            self.env["automation.configuration"].cron_automation()
+            record_activity = self.env["automation.record.step"].search(
+                [("configuration_step_id", "=", activity.id)]
+            )
+            self.assertEqual("scheduled", record_activity.state)
+            self.assertEqual(record_activity.scheduled_date, datetime(2025, 1, 2))
+
     def test_schedule_date_computation_days(self):
         with freeze_time("2022-01-01"):
             activity = self.create_server_action(

--- a/automation_oca/views/automation_configuration.xml
+++ b/automation_oca/views/automation_configuration.xml
@@ -207,6 +207,7 @@
                             <field name="parent_position" />
                             <field name="trigger_child_types" />
                             <field name="trigger_type_data" />
+                            <field name="trigger_date_kind" />
                             <field name="step_icon" />
                             <field name="step_name" />
                             <templates>
@@ -244,6 +245,17 @@
                                                 /> <t
                                                     t-esc="record.trigger_type_data.raw_value.message_configuration"
                                                 />
+                                            </div>
+                                            <div
+                                                t-if="record.trigger_date_kind.raw_value == 'date'"
+                                            >
+                                                <i
+                                                    class="fa fa-calendar pe-1"
+                                                    role="img"
+                                                    aria-label="At"
+                                                    title="At"
+                                                />
+                                                <field name="trigger_date_field" />
                                             </div>
                                             <strong>
                                                 <i

--- a/automation_oca/views/automation_configuration_step.xml
+++ b/automation_oca/views/automation_configuration_step.xml
@@ -30,6 +30,7 @@
                             <field name="model" invisible="1" />
                         </group>
                         <group>
+                            <field name="trigger_date_kind" />
                             <label for="trigger_interval" string="Trigger" />
                             <div class="container ps-0">
                                 <div class="row">
@@ -42,8 +43,26 @@
                                             nolabel="1"
                                         /></div>
                                 </div>
-                                <div class="row">
+                                <div
+                                    class="row"
+                                    attrs="{'invisible': [('trigger_date_kind', '!=', 'date')]}"
+                                >
                                     <span class="col-2">after</span>
+                                    <div class="col-10"><field
+                                            name="trigger_date_field_id"
+                                            nolabel="1"
+                                            attrs="{'required': [('trigger_date_kind', '=', 'date')]}"
+                                        /></div>
+                                </div>
+                                <div class="row">
+                                    <span
+                                        class="col-2"
+                                        attrs="{'invisible': [('trigger_date_kind', '!=', 'offset')]}"
+                                    >after</span>
+                                    <span
+                                        class="col-2"
+                                        attrs="{'invisible': [('trigger_date_kind', '=', 'offset')]}"
+                                    >when</span>
                                     <div class="col-10"><field
                                             name="trigger_type"
                                             nolabel="1"
@@ -62,6 +81,14 @@
                                 </div>
                             </div>
                             <field name="allow_expiry" invisible="1" />
+                            <div
+                                class="container ps-0 alert alert-warning"
+                                colspan="2"
+                                attrs="{'invisible': [('trigger_date_kind', '!=', 'date')]}"
+                            >
+                                The scheduled date will be the date of the record at the moment we generate the new record.
+                                Later changes of the field will not affect the scheduled date.
+                            </div>
                             <field
                                 name="expiry"
                                 attrs="{'invisible': [('allow_expiry', '=', False)]}"


### PR DESCRIPTION
This change is interesting to enforce something like:

- 10 days after the expected date of delivery of the sale order
- 3 days before expiral of the sale order.

I added a small warning in order to show that the date is computed at the moment of schedule of the task.

![image](https://github.com/user-attachments/assets/a5c4825e-169e-4cd1-bc28-a961bde34d3f)

![image](https://github.com/user-attachments/assets/295603b9-7a0a-4a82-b4ce-86f25cada3c6)