### PR TITLE
[16.0][IMP] automation_oca: Enforce verification domain on activities

### DIFF
--- a/automation_oca/models/automation_configuration_step.py
+++ b/automation_oca/models/automation_configuration_step.py
@@ -94,6 +94,13 @@ class AutomationConfigurationStep(models.Model):
     activity_note = fields.Html(
         "Note", compute="_compute_activity_info", readonly=False, store=True
     )
+    activity_verification_domain = fields.Char(
+        required=True, default="[]", help="Filter to verify when the activity is done"
+    )
+    activity_verification_domain_error = fields.Text(
+        translate=True,
+        help="Message to show when the activity domain is not as expected",
+    )
     activity_date_deadline_range = fields.Integer(
         string="Due Date In",
         compute="_compute_activity_info",

--- a/automation_oca/models/automation_record_step.py
+++ b/automation_oca/models/automation_record_step.py
@@ -9,6 +9,7 @@ import werkzeug.urls
 from dateutil.relativedelta import relativedelta
 
 from odoo import _, api, fields, models, tools
+from odoo.exceptions import ValidationError
 from odoo.tools.safe_eval import safe_eval
 
 
@@ -328,6 +329,17 @@ class AutomationRecordStep(models.Model):
         todo._trigger_activities()
 
     def _set_activity_done(self):
+        domain = safe_eval(
+            self.configuration_step_id.activity_verification_domain or "[]",
+            self.configuration_step_id.configuration_id._get_eval_context(),
+        )
+        if domain and not self.record_id.resource_ref.filtered_domain(domain):
+            raise ValidationError(
+                _(
+                    "The record does not fulfill the expected domain:\n%(domain)s",
+                    domain=self.configuration_step_id.activity_verification_domain_error,
+                )
+            )
         self.write({"activity_done_on": fields.Datetime.now()})
         self.child_ids.filtered(
             lambda r: r.trigger_type == "activity_done"

--- a/automation_oca/views/automation_configuration_step.xml
+++ b/automation_oca/views/automation_configuration_step.xml
@@ -165,6 +165,12 @@
                             <group>
                                 <field name="activity_summary" />
                                 <field name="activity_note" />
+                                <field
+                                    name="activity_verification_domain"
+                                    widget="domain"
+                                    options="{'foldable': True, 'model': 'model'}"
+                                />
+                                <field name="activity_verification_domain_error" />
                             </group>
                         </page>
                         <page name="action" string="Server Action">


### PR DESCRIPTION
Usually, we expect users to do some action on the activities, like filling the name and mobile or something like this. 

However, the system allowed to continue without verifying this, so later action might not happen properly.

With this change, we can enforce a verification domain on the activity to ensure that everything is filled for next actions.