### PR TITLE
[16.0][FIX] automation_oca: Check do_not_wait on activation too

### DIFF
--- a/automation_oca/models/automation_record_step.py
+++ b/automation_oca/models/automation_record_step.py
@@ -320,10 +320,17 @@ class AutomationRecordStep(models.Model):
 
     def _activate(self):
         todo = self.filtered(lambda r: not r.scheduled_date)
+        current_date = fields.Datetime.now()
         for record in todo:
             config = record.configuration_step_id
-            record.scheduled_date = fields.Datetime.now() + relativedelta(
+            scheduled_date = fields.Datetime.now() + relativedelta(
                 **{config.trigger_interval_type: config.trigger_interval}
+            )
+            record.write(
+                {
+                    "scheduled_date": scheduled_date,
+                    "do_not_wait": scheduled_date < current_date,
+                }
             )
         todo._trigger_activities()
 


### PR DESCRIPTION
On a previous PR, we allowed the execution to be done with the previous task.

However, it was not working in some special cases (like after activity is done). This fixes it.