### PR TITLE
[18.0][IMP-FIX] automation_oca: Define a more specific selector

### DIFF
--- a/automation_oca/static/src/views/automation_kanban/automation_kanban.scss
+++ b/automation_oca/static/src/views/automation_kanban/automation_kanban.scss
@@ -126,6 +126,8 @@
 .filter-left {
     text-align: left;
 }
-.o_kanban_renderer .o_kanban_record:not(.o_legacy_kanban_record):not(.o_kanban_ghost) {
-    border: none !important;
+.o_automation_upload_kanban_view
+    .o_kanban_renderer
+    .o_kanban_record:not(.o_legacy_kanban_record):not(.o_kanban_ghost) {
+    border: none;
 }


### PR DESCRIPTION
Applying a global style affects the styles of other views. To prevent this from happening, apply a more specific selector that only applies to the view of this module.

Before:
<img width="315" height="227" alt="image" src="https://github.com/user-attachments/assets/a0f30fc0-6edd-4721-be3a-76142ea6bf0c" />

Without style:
<img width="315" height="227" alt="image" src="https://github.com/user-attachments/assets/568fb50a-5ce2-4337-a5e1-80ff1cae4c7d" />

After:
<img width="315" height="227" alt="image" src="https://github.com/user-attachments/assets/2a01c259-5ca8-48bc-9bb3-d93c7072afa2" />


@pedrobaeza @CarlosRoca13 @david-banon-tecnativa please review
