### PR TITLE
[18.0][IMP] automation_oca: Change where the mock has to be loaded

### DIFF
--- a/automation_oca/tests/test_automation_date.py
+++ b/automation_oca/tests/test_automation_date.py
@@ -10,21 +10,19 @@ from .common import AutomationTestCase
 
 
 class TestAutomationDate(AutomationTestCase):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.loader = FakeModelLoader(cls.env, cls.__module__)
-        cls.loader.backup_registry()
+    def setUp(self):
+        super().setUp()
+        self.loader = FakeModelLoader(self.env, self.__module__)
+        self.loader.backup_registry()
 
         # The fake class is imported here !! After the backup_registry
         from .models import ResPartner
 
-        cls.loader.update_registry((ResPartner,))
+        self.loader.update_registry((ResPartner,))
 
-    @classmethod
-    def tearDownClass(cls):
-        cls.loader.restore_registry()
-        super().tearDownClass()
+    def tearDown(self):
+        self.loader.restore_registry()
+        return super().tearDown()
 
     def test_schedule_date_force(self):
         partner_01 = self.env["res.partner"].create(


### PR DESCRIPTION
Change where the mock has to be loaded

With the changes introduced in odoo/odoo@de056cc#diff-b37c7fd5520c97a29ddc59495779e7be61a66e15e85603928e27b3affb9dc31f, an error was occurring because the change validation on the model was being performed before tearDownClass was executed. Therefore, it has been modified so that the mock changes are applied in each test and cleaned up after each test. This way, the error will no longer appear and the test will run normally.

@Tecnativa