### PR TITLE
[17.0][IMP] automation_oca: Rename "Rejected" to "Skipped"

### DIFF
--- a/automation_oca/__manifest__.py
+++ b/automation_oca/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "Automation Oca",
     "summary": """
         Automate actions in threaded models""",
-    "version": "17.0.1.0.0",
+    "version": "17.0.1.1.0",
     "license": "AGPL-3",
     "category": "Automation",
     "author": "Dixmit,Odoo Community Association (OCA)",

--- a/automation_oca/i18n/automation_oca.pot
+++ b/automation_oca/i18n/automation_oca.pot
@@ -1145,13 +1145,6 @@ msgid "Records"
 msgstr ""
 
 #. module: automation_oca
-#: model:ir.model.fields.selection,name:automation_oca.selection__automation_record_step__state__rejected
-#: model_terms:ir.ui.view,arch_db:automation_oca.automation_record_form_view
-#: model_terms:ir.ui.view,arch_db:automation_oca.automation_record_step_search_view
-msgid "Rejected"
-msgstr ""
-
-#. module: automation_oca
 #. odoo-python
 #: code:addons/automation_oca/models/automation_record_step.py:0
 #: model:ir.model.fields.selection,name:automation_oca.selection__automation_record_step__mail_status__reply
@@ -1254,6 +1247,13 @@ msgid ""
 "Set a negative time trigger if you want the step to be executed\n"
 "        immediately, in parallel with the previous step, without waiting for it to\n"
 "        finish."
+msgstr ""
+
+#. module: automation_oca
+#: model:ir.model.fields.selection,name:automation_oca.selection__automation_record_step__state__skipped
+#: model_terms:ir.ui.view,arch_db:automation_oca.automation_record_form_view
+#: model_terms:ir.ui.view,arch_db:automation_oca.automation_record_step_search_view
+msgid "Skipped"
 msgstr ""
 
 #. module: automation_oca
@@ -1495,7 +1495,7 @@ msgstr ""
 #: code:addons/automation_oca/models/automation_record_step.py:0
 #, python-format
 msgid ""
-"You can only retry a record step in a rejected, expired, cancelled or error "
+"You can only retry a record step in a skipped, expired, cancelled or error "
 "state."
 msgstr ""
 

--- a/automation_oca/i18n/es.po
+++ b/automation_oca/i18n/es.po
@@ -6,15 +6,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: 2025-06-02 22:26+0000\n"
-"Last-Translator: \"Leonardo J. Caballero G.\" <leonardocaballero@gmail.com>\n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: 2026-02-27 14:57+0100\n"
+"Last-Translator: Pedro M. Baeza <pedro.baeza@tecnativa.com>\n"
 "Language-Team: none\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 5.10.4\n"
+"X-Generator: Poedit 3.8\n"
 
 #. module: automation_oca
 #: model:ir.model.fields,help:automation_oca.field_automation_configuration__domain
@@ -43,6 +44,14 @@ msgstr ""
 #, python-format
 msgid "%s configurations needs a parent"
 msgstr "%s configuraciones necesitan un padre"
+
+#. module: automation_oca
+#: model_terms:ir.ui.view,arch_db:automation_oca.automation_configuration_form_view
+msgid ""
+"<i class=\"fa fa-calendar pe-1\" role=\"img\" aria-label=\"At\" title=\"At\"/"
+">"
+msgstr ""
+"<i class=\"fa fa-calendar pe-1\" role=\"img\" aria-label=\"A\" title=\"A\"/>"
 
 #. module: automation_oca
 #: model_terms:ir.ui.view,arch_db:automation_oca.automation_configuration_form_view
@@ -97,6 +106,19 @@ msgstr ""
 "contacto.</p>\n"
 "            <p>Saludos cordiales,</p>\n"
 "        "
+
+#. module: automation_oca
+#: model_terms:ir.ui.view,arch_db:automation_oca.automation_configuration_step_form_view
+msgid ""
+"<span class=\"col-2\" invisible=\"trigger_date_kind != 'offset'\">after</"
+"span>\n"
+"                                    <span class=\"col-2\" "
+"invisible=\"trigger_date_kind == 'offset'\">when</span>"
+msgstr ""
+"<span class=\"col-2\" invisible=\"trigger_date_kind != 'offset'\">después</"
+"span>\n"
+"                                    <span class=\"col-2\" "
+"invisible=\"trigger_date_kind == 'offset'\">cuando</span>"
 
 #. module: automation_oca
 #: model_terms:ir.ui.view,arch_db:automation_oca.automation_configuration_step_form_view
@@ -179,6 +201,16 @@ msgstr "Número de correos de actividad"
 #: model:ir.model.fields,field_description:automation_oca.field_automation_configuration_step__activity_user_type
 msgid "Activity User Type"
 msgstr "Actividad tipo de usuario"
+
+#. module: automation_oca
+#: model:ir.model.fields,field_description:automation_oca.field_automation_configuration_step__activity_verification_domain
+msgid "Activity Verification Domain"
+msgstr "Dominio de verificación de la actividad"
+
+#. module: automation_oca
+#: model:ir.model.fields,field_description:automation_oca.field_automation_configuration_step__activity_verification_domain_error
+msgid "Activity Verification Domain Error"
+msgstr "Error de dominio de verificación de actividad"
 
 #. module: automation_oca
 #. odoo-python
@@ -307,13 +339,11 @@ msgstr "Configuración de automatización"
 
 #. module: automation_oca
 #: model:ir.actions.server,name:automation_oca.cron_configuration_run_ir_actions_server
-#: model:ir.cron,cron_name:automation_oca.cron_configuration_run
 msgid "Automation: Create records"
 msgstr "Automatización: Crear registros"
 
 #. module: automation_oca
 #: model:ir.actions.server,name:automation_oca.cron_step_execute_ir_actions_server
-#: model:ir.cron,cron_name:automation_oca.cron_step_execute
 msgid "Automation: Execute scheduled activities"
 msgstr "Automatización: Ejecutar actividades programadas"
 
@@ -588,6 +618,11 @@ msgid "Field"
 msgstr "Campo"
 
 #. module: automation_oca
+#: model:ir.model.fields,field_description:automation_oca.field_automation_configuration_step__trigger_date_field
+msgid "Field Label"
+msgstr "Etiqueta de campo"
+
+#. module: automation_oca
 #: model:ir.model.fields,field_description:automation_oca.field_automation_configuration__filter_id
 #: model_terms:ir.ui.view,arch_db:automation_oca.automation_configuration_form_view
 msgid "Filter"
@@ -628,6 +663,11 @@ msgid "Filter to apply specifically"
 msgstr "Filtro a aplicar específicamente"
 
 #. module: automation_oca
+#: model:ir.model.fields,help:automation_oca.field_automation_configuration_step__activity_verification_domain
+msgid "Filter to verify when the activity is done"
+msgstr "Filtro para verificar cuando la actividad está realizada"
+
+#. module: automation_oca
 #: model:ir.actions.act_window,name:automation_oca.automation_filter_act_window
 #: model:ir.ui.menu,name:automation_oca.automation_filter_menu
 msgid "Filters"
@@ -647,6 +687,11 @@ msgstr "Seguidores"
 #: model:ir.model.fields,field_description:automation_oca.field_automation_configuration__message_partner_ids
 msgid "Followers (Partners)"
 msgstr "Seguidores (Contactos)"
+
+#. module: automation_oca
+#: model:ir.model.fields.selection,name:automation_oca.selection__automation_configuration_step__trigger_date_kind__date
+msgid "Force on Record Date"
+msgstr "Forzar en la fecha del registro"
 
 #. module: automation_oca
 #: model_terms:ir.ui.view,arch_db:automation_oca.automation_configuration_form_view
@@ -738,17 +783,6 @@ msgstr "Es periódico"
 #: model:ir.model.fields,field_description:automation_oca.field_automation_record_step__is_test
 msgid "Is Test"
 msgstr "Es prueba"
-
-#. module: automation_oca
-#: model:ir.model.fields,field_description:automation_oca.field_automation_configuration____last_update
-#: model:ir.model.fields,field_description:automation_oca.field_automation_configuration_step____last_update
-#: model:ir.model.fields,field_description:automation_oca.field_automation_configuration_test____last_update
-#: model:ir.model.fields,field_description:automation_oca.field_automation_filter____last_update
-#: model:ir.model.fields,field_description:automation_oca.field_automation_record____last_update
-#: model:ir.model.fields,field_description:automation_oca.field_automation_record_step____last_update
-#: model:ir.model.fields,field_description:automation_oca.field_automation_tag____last_update
-msgid "Last Modified on"
-msgstr "Última modificación en"
 
 #. module: automation_oca
 #: model:ir.model.fields,field_description:automation_oca.field_automation_configuration__write_uid
@@ -862,11 +896,6 @@ msgid "Mail replied"
 msgstr "Correo respondido"
 
 #. module: automation_oca
-#: model:ir.model.fields,field_description:automation_oca.field_automation_configuration__message_main_attachment_id
-msgid "Main Attachment"
-msgstr "Adjunto principal"
-
-#. module: automation_oca
 #: model:res.groups,name:automation_oca.group_automation_manager
 msgid "Manager"
 msgstr "Gerente"
@@ -892,21 +921,30 @@ msgid "Message Delivery error"
 msgstr "Error de entrega de mensaje"
 
 #. module: automation_oca
+#: model:ir.model.fields,help:automation_oca.field_automation_configuration_step__activity_verification_domain_error
+msgid "Message to show when the activity domain is not as expected"
+msgstr "Mensaje a mostrar cuando el dominio de la actividad no es el esperado"
+
+#. module: automation_oca
 #: model:ir.model.fields,field_description:automation_oca.field_automation_configuration__message_ids
 msgid "Messages"
 msgstr "Mensajes"
 
 #. module: automation_oca
 #: model:ir.model.fields,field_description:automation_oca.field_automation_configuration__model
-#: model:ir.model.fields,field_description:automation_oca.field_automation_configuration__model_id
 #: model:ir.model.fields,field_description:automation_oca.field_automation_configuration_step__model
-#: model:ir.model.fields,field_description:automation_oca.field_automation_configuration_step__model_id
 #: model:ir.model.fields,field_description:automation_oca.field_automation_configuration_test__model
 #: model:ir.model.fields,field_description:automation_oca.field_automation_filter__model
-#: model:ir.model.fields,field_description:automation_oca.field_automation_filter__model_id
 #: model:ir.model.fields,field_description:automation_oca.field_automation_record__model
 msgid "Model"
 msgstr "Modelo"
+
+#. module: automation_oca
+#: model:ir.model.fields,field_description:automation_oca.field_automation_configuration__model_id
+#: model:ir.model.fields,field_description:automation_oca.field_automation_configuration_step__model_id
+#: model:ir.model.fields,field_description:automation_oca.field_automation_filter__model_id
+msgid "Model ID"
+msgstr "ID de modelo"
 
 #. module: automation_oca
 #: model:ir.model.fields,help:automation_oca.field_automation_configuration__model_id
@@ -1015,6 +1053,11 @@ msgstr "Número de mensajes que requieren acción"
 #: model:ir.model.fields,help:automation_oca.field_automation_configuration__message_has_error_counter
 msgid "Number of messages with delivery error"
 msgstr "Número de mensajes con error de entrega"
+
+#. module: automation_oca
+#: model:ir.model.fields.selection,name:automation_oca.selection__automation_configuration_step__trigger_date_kind__offset
+msgid "Offset"
+msgstr "Desplazamiento"
 
 #. module: automation_oca
 #: model_terms:ir.ui.view,arch_db:automation_oca.automation_configuration_form_view
@@ -1154,13 +1197,6 @@ msgid "Records"
 msgstr "Registros"
 
 #. module: automation_oca
-#: model:ir.model.fields.selection,name:automation_oca.selection__automation_record_step__state__rejected
-#: model_terms:ir.ui.view,arch_db:automation_oca.automation_record_form_view
-#: model_terms:ir.ui.view,arch_db:automation_oca.automation_record_step_search_view
-msgid "Rejected"
-msgstr "Rechazado"
-
-#. module: automation_oca
 #. odoo-python
 #: code:addons/automation_oca/models/automation_record_step.py:0
 #: model:ir.model.fields.selection,name:automation_oca.selection__automation_record_step__mail_status__reply
@@ -1190,6 +1226,11 @@ msgstr "Referencia de recurso"
 #: model:ir.model.fields,field_description:automation_oca.field_automation_configuration_step__activity_user_id
 msgid "Responsible"
 msgstr "Responsable"
+
+#. module: automation_oca
+#: model_terms:ir.ui.view,arch_db:automation_oca.automation_record_form_view
+msgid "Retry"
+msgstr "Reintentar"
 
 #. module: automation_oca
 #: model_terms:ir.ui.view,arch_db:automation_oca.automation_configuration_search_view
@@ -1236,8 +1277,21 @@ msgstr "Enviado"
 #. module: automation_oca
 #: model:ir.model.fields,field_description:automation_oca.field_automation_configuration_step__server_action_id
 #: model:ir.model.fields.selection,name:automation_oca.selection__automation_configuration_step__step_type__action
+#: model_terms:ir.ui.view,arch_db:automation_oca.automation_configuration_step_form_view
 msgid "Server Action"
 msgstr "Acción de servidor"
+
+#. module: automation_oca
+#: model:ir.model.fields,field_description:automation_oca.field_automation_configuration_step__server_context
+msgid "Server Context"
+msgstr "Contexto de servidor"
+
+#. module: automation_oca
+#. odoo-python
+#: code:addons/automation_oca/models/automation_configuration_step.py:0
+#, python-format
+msgid "Server Context is not wellformed"
+msgstr "El contexto de servidor no está correctamente formado"
 
 #. module: automation_oca
 #: model:ir.model.fields,help:automation_oca.field_automation_configuration_step__trigger_interval
@@ -1250,6 +1304,13 @@ msgstr ""
 "Define un tiempo negativo si quieres que el registro se ejecute\n"
 "        inmediatamente, en paralelo, sin esperar que acabe el \n"
 "        anterior."
+
+#. module: automation_oca
+#: model:ir.model.fields.selection,name:automation_oca.selection__automation_record_step__state__skipped
+#: model_terms:ir.ui.view,arch_db:automation_oca.automation_record_form_view
+#: model_terms:ir.ui.view,arch_db:automation_oca.automation_record_step_search_view
+msgid "Skipped"
+msgstr "Saltado"
 
 #. module: automation_oca
 #: model_terms:ir.ui.view,arch_db:automation_oca.automation_configuration_step_form_view
@@ -1352,6 +1413,30 @@ msgid "Tests"
 msgstr "Pruebas"
 
 #. module: automation_oca
+#. odoo-python
+#: code:addons/automation_oca/models/automation_record_step.py:0
+#, python-format
+msgid ""
+"The record does not fulfill the expected domain:\n"
+"%(domain)s"
+msgstr ""
+"El registro no cumple con el dominio esperado:\n"
+"%(domain)s"
+
+#. module: automation_oca
+#: model_terms:ir.ui.view,arch_db:automation_oca.automation_configuration_step_form_view
+msgid ""
+"The scheduled date will be the date of the record at the moment we generate "
+"the new record.\n"
+"                                Later changes of the field will not affect "
+"the scheduled date."
+msgstr ""
+"La fecha de publicación será la fecha en la que se genera el nuevo "
+"registro.\n"
+"                                Cambios posteriores de los campos no "
+"afectarán a la fecha planificada."
+
+#. module: automation_oca
 #: model_terms:ir.ui.view,arch_db:automation_oca.automation_configuration_form_view
 msgid ""
 "This a periodical configuration. New records are generated automatically.\n"
@@ -1399,6 +1484,16 @@ msgstr "Disparador"
 #: model:ir.model.fields,field_description:automation_oca.field_automation_configuration_step__trigger_child_types
 msgid "Trigger Child Types"
 msgstr "Tipos de hijos de disparador"
+
+#. module: automation_oca
+#: model:ir.model.fields,field_description:automation_oca.field_automation_configuration_step__trigger_date_field_id
+msgid "Trigger Date Field"
+msgstr "Campo de fecha disparadora"
+
+#. module: automation_oca
+#: model:ir.model.fields,field_description:automation_oca.field_automation_configuration_step__trigger_date_kind
+msgid "Trigger Date Kind"
+msgstr "Tipo de fecha disparadora"
 
 #. module: automation_oca
 #: model:ir.model.fields,field_description:automation_oca.field_automation_configuration_step__trigger_interval
@@ -1477,6 +1572,17 @@ msgid "Welcome! Thanks for being part of our database"
 msgstr "¡Bienvenido! Gracias por ser parte de nuestra base de datos"
 
 #. module: automation_oca
+#. odoo-python
+#: code:addons/automation_oca/models/automation_record_step.py:0
+#, python-format
+msgid ""
+"You can only retry a record step in a skipped, expired, cancelled or error "
+"state."
+msgstr ""
+"Solo puede reintentar un paso que esté en estado saltado, expirado,cancelado "
+"o error."
+
+#. module: automation_oca
 #: model_terms:ir.ui.view,arch_db:automation_oca.automation_configuration_form_view
 #: model_terms:ir.ui.view,arch_db:automation_oca.automation_configuration_step_form_view
 msgid "e.g. Remember unpaid invoices"
@@ -1495,6 +1601,12 @@ msgstr "ejecución de otro paso"
 #, python-format
 msgid "start of workflow"
 msgstr "inicio de flujo de trabajo"
+
+#~ msgid "Last Modified on"
+#~ msgstr "Última modificación en"
+
+#~ msgid "Main Attachment"
+#~ msgstr "Adjunto principal"
 
 #~ msgid "Days"
 #~ msgstr "Días"

--- a/automation_oca/i18n/es_VE.po
+++ b/automation_oca/i18n/es_VE.po
@@ -1190,13 +1190,6 @@ msgid "Records"
 msgstr "Registros"
 
 #. module: automation_oca
-#: model:ir.model.fields.selection,name:automation_oca.selection__automation_record_step__state__rejected
-#: model_terms:ir.ui.view,arch_db:automation_oca.automation_record_form_view
-#: model_terms:ir.ui.view,arch_db:automation_oca.automation_record_step_search_view
-msgid "Rejected"
-msgstr "Rechazado"
-
-#. module: automation_oca
 #. odoo-python
 #: code:addons/automation_oca/models/automation_record_step.py:0
 #: model:ir.model.fields.selection,name:automation_oca.selection__automation_record_step__mail_status__reply
@@ -1303,6 +1296,13 @@ msgstr ""
 "Define un tiempo negativo si quieres que el registro se ejecute\n"
 "        inmediatamente, en paralelo, sin esperar que acabe el \n"
 "        anterior."
+
+#. module: automation_oca
+#: model:ir.model.fields.selection,name:automation_oca.selection__automation_record_step__state__skipped
+#: model_terms:ir.ui.view,arch_db:automation_oca.automation_record_form_view
+#: model_terms:ir.ui.view,arch_db:automation_oca.automation_record_step_search_view
+msgid "Skipped"
+msgstr "Saltado"
 
 #. module: automation_oca
 #: model_terms:ir.ui.view,arch_db:automation_oca.automation_configuration_step_form_view

--- a/automation_oca/i18n/fr.po
+++ b/automation_oca/i18n/fr.po
@@ -1134,13 +1134,6 @@ msgid "Records"
 msgstr ""
 
 #. module: automation_oca
-#: model:ir.model.fields.selection,name:automation_oca.selection__automation_record_step__state__rejected
-#: model_terms:ir.ui.view,arch_db:automation_oca.automation_record_form_view
-#: model_terms:ir.ui.view,arch_db:automation_oca.automation_record_step_search_view
-msgid "Rejected"
-msgstr "Rejeté"
-
-#. module: automation_oca
 #. odoo-python
 #: code:addons/automation_oca/models/automation_record_step.py:0
 #: model:ir.model.fields.selection,name:automation_oca.selection__automation_record_step__mail_status__reply
@@ -1227,6 +1220,13 @@ msgid ""
 "it to\n"
 "        finish."
 msgstr ""
+
+#. module: automation_oca
+#: model:ir.model.fields.selection,name:automation_oca.selection__automation_record_step__state__skipped
+#: model_terms:ir.ui.view,arch_db:automation_oca.automation_record_form_view
+#: model_terms:ir.ui.view,arch_db:automation_oca.automation_record_step_search_view
+msgid "Skipped"
+msgstr "Sauté"
 
 #. module: automation_oca
 #: model_terms:ir.ui.view,arch_db:automation_oca.automation_configuration_step_form_view

--- a/automation_oca/i18n/it.po
+++ b/automation_oca/i18n/it.po
@@ -1157,13 +1157,6 @@ msgid "Records"
 msgstr "Record"
 
 #. module: automation_oca
-#: model:ir.model.fields.selection,name:automation_oca.selection__automation_record_step__state__rejected
-#: model_terms:ir.ui.view,arch_db:automation_oca.automation_record_form_view
-#: model_terms:ir.ui.view,arch_db:automation_oca.automation_record_step_search_view
-msgid "Rejected"
-msgstr "Respinta"
-
-#. module: automation_oca
 #. odoo-python
 #: code:addons/automation_oca/models/automation_record_step.py:0
 #: model:ir.model.fields.selection,name:automation_oca.selection__automation_record_step__mail_status__reply
@@ -1254,6 +1247,13 @@ msgstr ""
 "        venga eseguito immediatamente, parallelamente al passaggio "
 "precedente,\n"
 "        senza attendere che termini."
+
+#. module: automation_oca
+#: model:ir.model.fields.selection,name:automation_oca.selection__automation_record_step__state__skipped
+#: model_terms:ir.ui.view,arch_db:automation_oca.automation_record_form_view
+#: model_terms:ir.ui.view,arch_db:automation_oca.automation_record_step_search_view
+msgid "Skipped"
+msgstr "Saltato"
 
 #. module: automation_oca
 #: model_terms:ir.ui.view,arch_db:automation_oca.automation_configuration_step_form_view

--- a/automation_oca/migrations/17.0.1.1.0/pre-migration.py
+++ b/automation_oca/migrations/17.0.1.1.0/pre-migration.py
@@ -1,0 +1,8 @@
+# Copyright 2026 Tecnativa - Pedro M. Baeza
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+
+def migrate(cr, version):
+    cr.execute(
+        "UPDATE automation_record_step SET state='skipped' WHERE state='rejected'"
+    )

--- a/automation_oca/models/automation_configuration_step.py
+++ b/automation_oca/models/automation_configuration_step.py
@@ -257,7 +257,7 @@ class AutomationConfigurationStep(models.Model):
             record.graph_error = self.env["automation.record.step"].search_count(
                 [
                     ("configuration_step_id", "=", record.id),
-                    ("state", "in", ["expired", "rejected", "error", "cancel"]),
+                    ("state", "in", ["expired", "skipped", "error", "cancel"]),
                     ("is_test", "=", False),
                 ]
             )

--- a/automation_oca/models/automation_record_step.py
+++ b/automation_oca/models/automation_record_step.py
@@ -54,7 +54,7 @@ class AutomationRecordStep(models.Model):
             ("scheduled", "Scheduled"),
             ("done", "Done"),
             ("expired", "Expired"),
-            ("rejected", "Rejected"),
+            ("skipped", "Skipped"),
             ("error", "Error"),
             ("cancel", "Cancelled"),
         ],
@@ -154,7 +154,7 @@ class AutomationRecordStep(models.Model):
             )
             or not self._check_to_execute()
         ):
-            self._reject()
+            self._skip()
             return self.browse()
         try:
             result = getattr(self, f"_run_{self.configuration_step_id.step_type}")()
@@ -177,8 +177,12 @@ class AutomationRecordStep(models.Model):
             )
         return self.browse()
 
+    def _skip(self):
+        self.write({"state": "skipped", "processed_on": fields.Datetime.now()})
+
     def _reject(self):
-        self.write({"state": "rejected", "processed_on": fields.Datetime.now()})
+        # FIXME: Kept for retro-compatibility
+        self._skip()
 
     def _fill_childs(self, **kwargs):
         return self.create(
@@ -344,7 +348,7 @@ class AutomationRecordStep(models.Model):
             lambda r: r.trigger_type == "activity_cancel"
             and not r.scheduled_date
             and r.state == "scheduled"
-        )._reject()
+        )._skip()
 
     def _set_activity_cancel(self):
         self.write({"activity_cancel_on": fields.Datetime.now()})
@@ -357,7 +361,7 @@ class AutomationRecordStep(models.Model):
             lambda r: r.trigger_type == "activity_done"
             and not r.scheduled_date
             and r.state == "scheduled"
-        )._reject()
+        )._skip()
 
     def _set_mail_bounced(self):
         self.write({"mail_status": "bounce"})
@@ -461,10 +465,10 @@ class AutomationRecordStep(models.Model):
         """
         Retry the record step
         """
-        if self.state not in ["error", "rejected", "expired", "cancel"]:
+        if self.state not in ["error", "skipped", "expired", "cancel"]:
             raise ValidationError(
                 _(
-                    "You can only retry a record step in a rejected, "
+                    "You can only retry a record step in a skipped, "
                     "expired, cancelled or error state."
                 )
             )

--- a/automation_oca/tests/test_automation_action.py
+++ b/automation_oca/tests/test_automation_action.py
@@ -158,7 +158,7 @@ class TestAutomationAction(AutomationTestCase):
                 [
                     ("configuration_step_id", "=", activity_1_2.id),
                     ("record_id.res_id", "=", self.partner_01.id),
-                    ("state", "=", "rejected"),
+                    ("state", "=", "skipped"),
                 ]
             ),
         )
@@ -168,7 +168,7 @@ class TestAutomationAction(AutomationTestCase):
                 [
                     ("configuration_step_id", "=", activity_1_1.id),
                     ("record_id.res_id", "=", self.partner_02.id),
-                    ("state", "=", "rejected"),
+                    ("state", "=", "skipped"),
                 ]
             ),
         )

--- a/automation_oca/tests/test_automation_activity.py
+++ b/automation_oca/tests/test_automation_activity.py
@@ -182,7 +182,7 @@ class TestAutomationActivity(AutomationTestCase):
         self.partner_01.activity_ids.unlink()
         self.assertFalse(record_activity.activity_done_on)
         self.assertFalse(record_child_activity.scheduled_date)
-        self.assertEqual(record_child_activity.state, "rejected")
+        self.assertEqual(record_child_activity.state, "skipped")
 
     def test_activity_execution_on_cancel_permission(self):
         """
@@ -211,7 +211,7 @@ class TestAutomationActivity(AutomationTestCase):
         self.partner_01.activity_ids.with_user(self.user.id).unlink()
         self.assertFalse(record_activity.activity_done_on)
         self.assertFalse(record_child_activity.scheduled_date)
-        self.assertEqual(record_child_activity.state, "rejected")
+        self.assertEqual(record_child_activity.state, "skipped")
 
     def test_activity_execution_cancel_child(self):
         """
@@ -268,7 +268,7 @@ class TestAutomationActivity(AutomationTestCase):
         self.partner_01.activity_ids.action_feedback()
         self.assertFalse(record_activity.activity_cancel_on)
         self.assertFalse(record_child_activity.scheduled_date)
-        self.assertEqual(record_child_activity.state, "rejected")
+        self.assertEqual(record_child_activity.state, "skipped")
 
     def test_activity_execution_not_done_child_done(self):
         """
@@ -299,7 +299,7 @@ class TestAutomationActivity(AutomationTestCase):
         self.assertTrue(record_child_activity.scheduled_date)
         self.assertEqual("scheduled", record_child_activity.state)
         record_child_activity.run()
-        self.assertEqual("rejected", record_child_activity.state)
+        self.assertEqual("skipped", record_child_activity.state)
 
     def test_activity_execution_not_done_child_not_done(self):
         """

--- a/automation_oca/tests/test_automation_mail.py
+++ b/automation_oca/tests/test_automation_mail.py
@@ -200,7 +200,7 @@ class TestAutomationMail(AutomationTestCase, MockEmail, HttpCase):
         )
         self.assertEqual("reply", record_activity.mail_status)
         self.env["automation.record.step"]._cron_automation_steps()
-        self.assertEqual("rejected", record_child_activity.state)
+        self.assertEqual("skipped", record_child_activity.state)
 
     def test_open(self):
         """
@@ -300,9 +300,9 @@ class TestAutomationMail(AutomationTestCase, MockEmail, HttpCase):
         self.env["automation.record.step"]._cron_automation_steps()
         self.assertEqual("done", record_child_activity.state)
 
-    def test_no_open_rejected(self):
+    def test_no_open_skipped(self):
         """
-        Now we will check the not open validation when it was already opened (rejection)
+        Now we will check the not open validation when it was already opened (skipped)
         """
         activity = self.create_mail_activity()
         child_activity = self.create_mail_activity(
@@ -326,7 +326,7 @@ class TestAutomationMail(AutomationTestCase, MockEmail, HttpCase):
         self.url_open(record_activity._get_mail_tracking_url())
         self.assertEqual("open", record_activity.mail_status)
         self.env["automation.record.step"]._cron_automation_steps()
-        self.assertEqual("rejected", record_child_activity.state)
+        self.assertEqual("skipped", record_child_activity.state)
 
     def test_click(self):
         """
@@ -487,10 +487,8 @@ class TestAutomationMail(AutomationTestCase, MockEmail, HttpCase):
         self.env["automation.record.step"]._cron_automation_steps()
         self.assertEqual("done", record_child_activity.state)
 
-    def test_no_click_rejected(self):
-        """
-        Checking the not clicked validation when it was already clicked
-        """
+    def test_no_click_skipped(self):
+        """Checking the not clicked validation when it was already clicked."""
         activity = self.create_mail_activity()
         child_activity = self.create_mail_activity(
             parent_id=activity.id, trigger_type="mail_not_clicked"
@@ -521,7 +519,7 @@ class TestAutomationMail(AutomationTestCase, MockEmail, HttpCase):
             allow_redirects=False,
         )
         self.env["automation.record.step"]._cron_automation_steps()
-        self.assertEqual("rejected", record_child_activity.state)
+        self.assertEqual("skipped", record_child_activity.state)
 
     def test_is_test_behavior(self):
         """

--- a/automation_oca/views/automation_record.xml
+++ b/automation_oca/views/automation_record.xml
@@ -103,9 +103,9 @@
                                                 </span>
                                                 <span
                                                     class="text-info"
-                                                    t-elif="record.state.raw_value == 'rejected'"
+                                                    t-elif="record.state.raw_value == 'skipped'"
                                                 >
-                                                    Rejected <field
+                                                    Skipped <field
                                                         name="processed_on"
                                                     />
                                                 </span>
@@ -143,7 +143,7 @@
                                     <div class="o_automation_kanban_card">
                                         <div class="o_automation_kanban_header">
                                             <div
-                                                t-attf-class="o_automation_kanban_header_icon {{record.state.raw_value === 'done' ? 'btn-success': (record.state.raw_value === 'scheduled' ? 'btn-primary': (record.state.raw_value === 'error' ? 'btn-danger': (record.state.raw_value === 'rejected' ? 'btn-info': 'btn-warning')))}}"
+                                                t-attf-class="o_automation_kanban_header_icon {{record.state.raw_value === 'done' ? 'btn-success': (record.state.raw_value === 'scheduled' ? 'btn-primary': (record.state.raw_value === 'error' ? 'btn-danger': (record.state.raw_value === 'skipped' ? 'btn-info': 'btn-warning')))}}"
                                             >
                                                 <span
                                                     t-att-class="record.step_icon.raw_value"
@@ -188,7 +188,7 @@
                                                     name="retry"
                                                     class="fa fa-refresh btn-warning o_automation_kanban_header_icon"
                                                     title="Retry"
-                                                    t-if="record.state.raw_value  == 'cancel' || record.state.raw_value  == 'rejected' || record.state.raw_value  ==  'error' || record.state.raw_value  ==  'expired'"
+                                                    t-if="record.state.raw_value  == 'cancel' || record.state.raw_value  == 'skipped' || record.state.raw_value  ==  'error' || record.state.raw_value  ==  'expired'"
                                                 />
                                             </div>
                                         </div>

--- a/automation_oca/views/automation_record_step.xml
+++ b/automation_oca/views/automation_record_step.xml
@@ -63,9 +63,9 @@
                     domain="[('state', '=', 'expired')]"
                 />
                 <filter
-                    string="Rejected"
-                    name="rejected"
-                    domain="[('state', '=', 'rejected')]"
+                    string="Skipped"
+                    name="skipped"
+                    domain="[('state', '=', 'skipped')]"
                 />
                 <filter
                     string="Error"


### PR DESCRIPTION
It's an ambiguous terminology, specially when the action is to send an email, thinking that the recipient has rejected somehow the content.
    
Thus, let's rename it to "Skipped" to be clearer, both in the technical and the label part.
    
All the references, translations and tests has been adapted accordingly. It also includes a migration script for switching to the new DB value.

@Tecnativa TT61258